### PR TITLE
Uses descendants to grab all pages

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -22,44 +22,47 @@ const getItemData = async () => {
 
   /* date */
   const itemResp = await fetch(`${firebaseUrl}/item/${itemId}.json`);
-  const { time } = await itemResp.json();
+  const { time, descendants } = await itemResp.json();
   const createdAt = new Date(time * 1000);
   const date = `${createdAt.getMonth() + 1}/${createdAt.getFullYear()}`;
-
-  return { postUrl, date };
+  return { postUrl, date, descendants };
 };
 
 async function collector(itemId) {
   const comments = [];
   const commentTrends = {};
-  const { postUrl, date } = await getItemData();
-  const resp = await axios.get(postUrl);
-  const $ = await cheerio.load(resp.data);
-  const elems = await $('img[width=0]');
+  const { postUrl, date, descendants } = await getItemData();
+  const totalPages = Math.floor(descendants / 200);
 
-  elems.each((i, elem) => {
-    const comment = $(elem)
-      .parent()
-      .siblings('td.default')
-      .children('.comment')
-      .clone()
-      .find('.reply')
-      .remove()
-      .end();
-    const commentText = `${comment.html()}`;
-    trends.forEach(t => {
-      const re = new RegExp(`\\s${t}`, 'i');
-      if (commentText.match(re)) {
-        Reflect.has(commentTrends, t)
-          ? (commentTrends[t] += 1)
-          : (commentTrends[t] = 1);
-      }
+  for (let page = 1; page <= totalPages; page++) {
+    const resp = await axios.get(postUrl + `&p=${page}`);
+    const $ = await cheerio.load(resp.data);
+    const elems = await $('img[width=0]');
+
+    elems.each((i, elem) => {
+      const comment = $(elem)
+        .parent()
+        .siblings('td.default')
+        .children('.comment')
+        .clone()
+        .find('.reply')
+        .remove()
+        .end();
+      const commentText = `${comment.html()}`;
+      trends.forEach(t => {
+        const re = new RegExp(`\\s${t}`, 'i');
+        if (commentText.match(re)) {
+          Reflect.has(commentTrends, t)
+            ? (commentTrends[t] += 1)
+            : (commentTrends[t] = 1);
+        }
+      });
+      comments.push({
+        text: commentText,
+        itemId: new Date().toISOString()
+      });
     });
-    comments.push({
-      text: commentText,
-      itemId: new Date().toISOString()
-    });
-  });
+  }
 
   return { comments, date, commentTrends };
 }


### PR DESCRIPTION
Changes the collector to grab all of the paginated results.  This should fix #4 

Note: This is more of a quick fix instead of a great long term solution since it increases the loading time a bit.  I think it would be worthwhile later to try and leverage `Promise.all` w/ `axios` to grab all the pages concurrently.  