### PR TITLE
fix: Overlapping scrollbars of `html` and `main`

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -11,7 +11,7 @@ interface HeaderProps {
 
 export default function Header({ searchText, story, stories }: HeaderProps) {
   return (
-    <header className="box-sizing border-b border-b-slate-300 bg-stone-50">
+    <header className="box-sizing sticky top-0 z-10 border-b border-b-slate-300 bg-stone-50">
       <div className="mx-auto flex h-28 max-w-5xl flex-col justify-between py-1 px-4 pb-3 sm:h-20 sm:flex-row sm:items-center sm:py-0 sm:pb-0">
         <div className="flex items-center justify-between sm:justify-start">
           <div className="mr-6 flex items-center">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -169,7 +169,7 @@ export default function Index() {
         <Header story={story} stories={stories} searchText={searchText} />
         <main
           ref={scrollableRef}
-          className="relative h-[calc(100vh-113px)] overflow-scroll bg-slate-200 pb-10 sm:h-[calc(100vh-81px)]"
+          className="relative bg-slate-200 pb-10"
         >
           <div className="mx-auto mt-8 flex flex-col bg-stone-50 p-4 text-slate-700 lg:max-w-5xl">
             <div className="flex flex-col gap-8">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -165,13 +165,11 @@ export default function Index() {
 
   return (
     <ItemsFiltersDispatch.Provider value={{ filterItems }}>
-      <div
-        ref={scrollableRef}
-        className="bg-slate-200 h-screen overflow-scroll"
-      >
+      <div className="flex flex-col h-screen bg-slate-200">
         <Header story={story} stories={stories} searchText={searchText} />
         <main
-          className="relative bg-slate-200 pb-10"
+          ref={scrollableRef}
+          className="relative overflow-scroll bg-slate-200 pb-10"
         >
           <div className="mx-auto mt-8 flex flex-col bg-stone-50 p-4 text-slate-700 lg:max-w-5xl">
             <div className="flex flex-col gap-8">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -165,10 +165,12 @@ export default function Index() {
 
   return (
     <ItemsFiltersDispatch.Provider value={{ filterItems }}>
-      <div className="bg-slate-200">
+      <div
+        ref={scrollableRef}
+        className="bg-slate-200 h-screen overflow-scroll"
+      >
         <Header story={story} stories={stories} searchText={searchText} />
         <main
-          ref={scrollableRef}
           className="relative bg-slate-200 pb-10"
         >
           <div className="mx-auto mt-8 flex flex-col bg-stone-50 p-4 text-slate-700 lg:max-w-5xl">


### PR DESCRIPTION
Remove `px` based height calculation of main element (e.g. `h-[calc(100vh-113px)]`). Such calculations don't create expected rendering on other displays of different font and resolution configurations. With miss-calculation, `html` may overflow and create an overlapping scrollbar.

This change fixes the issue.

Fixes #23 